### PR TITLE
Fixes #177: Alerts lost (orphaned) on deactivation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-The Thank You/Like System plugin for MyBB 1.8.x
-===============================================
+# The Thank You/Like System plugin for MyBB 1.8.x
 
 This is one of the best plugins for MyBB. It needed some love, so its current maintainers decided to adopt it to fix known bugs and make it even better. We have added many useful features, including MyAlerts support. Give it a try and let us know what you think!
 
@@ -8,62 +7,132 @@ For more information, see the plugin's:
 - [Extend MyBB page](http://community.mybb.com/mods.php?action=view&pid=360).
 - [MyBB Community Forums topic](http://community.mybb.com/thread-169382.html).
 
-Installing
-----------
+## Installing
 
-1. Download an archive of the plugin's files from its Extend MyBB page linked to above.
-2. Extract the files in that archive to a temporary location, and then copy them into the root of your MyBB installation. That is to say that "tylsearch.php" should be copied to your MyBB root, "jscripts/thankyoulike.js" should be copied to your MyBB root's "jscripts/" directory, etc.
-3. In a web browser, open the "Plugins" module in the Admin Control Panel (ACP) of your MyBB installation. You should see "Thank You/Like System" under "Inactive Plugins".
-4. Click "Install & Activate" next to it. You should then see the plugin listed under "Active Plugins" on the reloaded page.
-5. Click "Configure Settings" below the plugin and set up the plugin to your preferences.
-6. If you want to, you can also edit the plugin's stylesheet ("thankyoulike.css", accessible via the ACP under Templates & Style -> Themes) and its templates (under "Thank You/Like Templates", accessible via the ACP under Templates & Style -> Templates).
+1. *Download*.
 
-Upgrading
----------
+   Download an archive of the plugin's files from its Extend MyBB page linked to above.
 
-If you are upgrading to version 2.4.0 or above, then follow these steps:
+2. *Copy files*.
 
-1. Click the "Deactivate" button beside the Thank You/Like System plugin in the ACP "Plugins" module.
-2. Copy the new version's files, overwriting the old ones (per steps #1 and #2 of Installing above).
-3. Activate the plugin again via the ACP. This will upgrade the plugin, retaining all data, including received and given thanks/likes, per-user counts of thanks/likes, overall thanks/likes statistics, the plugin's settings including per-usergroup settings, any changes made to the plugin's stylesheet, and any changes made to the plugin's templates.
-4. If you had modified any of the plugin's templates, then, as when upgrading MyBB core, go to "Find Updated Templates" in the ACP to see whether you need to perform any updates.
-5. If you had modified the plugin's stylesheet (thankyoulike.css) for any themes, then you might need to apply any changes to this file that came with the new version of the plugin. You can check whether there are any changes in the new Master version of thankyoulike.css that need to be applied by clicking "View the Master theme's thankyoulike.css" under the plugin's entry in the ACP "Plugins" module and comparing it with your existing thankyoulike.css theme files (via the ACP under Templates & Style -> Themes).
+   Extract the files in that archive to a temporary location, and then copy them into the root of your MyBB installation. That is to say that "tylsearch.php" should be copied to your MyBB root, "jscripts/thankyoulike.js" should be copied to your MyBB root's "jscripts/" directory, etc.
 
-If you are upgrading to version 2.3.0 or below, then:
+3. *Install via the ACP*.
 
-If the updated version of the plugin does not contain new settings or changes to its templates or stylesheet, then:
+   In a web browser, open the "Plugins" module in the Admin Control Panel (ACP) of your MyBB installation. You should see "Thank You/Like System" under "Inactive Plugins". Click "Install & Activate" next to it. You should then see the plugin listed under "Active Plugins" on the reloaded page.
 
-1. Click the "Deactivate" button beside the Thank You/Like System plugin in the ACP "Plugins" module.
-2. Copy the new version's files, overwriting the old ones (per steps #1 and #2 of Installing above).
-3. Activate the plugin again via the ACP. All data will be retained, including received and given thanks/likes, per-user counts of thanks/likes, overall thanks/likes statistics, the plugin's settings including per-usergroup settings, any changes made to the plugin's stylesheet, and any changes made to the plugin's templates.
+4. *Configure settings*.
 
-If the updated version of the plugin <strong>does</strong> contain new settings or changes to its templates or stylesheet, then:
+   Click "Configure Settings" below the plugin and set up the plugin to your preferences.
 
-1. Make a note of your ACP settings for this plugin including per-usergroup settings (applicable when the plugin's "Usergroup-based thanks/likes limits" setting is enabled), any changes you have made to the plugin's stylesheet file ("thankyoulike.css", accessible via the ACP under Templates & Style -> Themes) and any changes you have to to the plugin's templates (under "Thank You/Like Templates", accessible via the ACP under Templates & Style -> Templates).
-2. Click the "Uninstall" button beside the Thank You/Like System plugin in the ACP "Plugins" module and choose "NO" when asked whether to drop plugin data from the database.
-3. Copy the new version's files, overwriting the old ones (per steps #1 and #2 of Installing above).
-4. Install and activate the plugin again via the ACP.
-5. Re-enter your settings for the plugin including any per-usergroup settings and any changes you had made to the plugin's stylesheet and templates (this is why it is important to have made a note of them before uninstalling the plugin).
+5. *Configure style and templates*.
 
-Credits
--------
+   If you want to, you can also edit the plugin's stylesheet ("thankyoulike.css", accessible via the ACP under Templates & Style -> Themes) and its templates (under "Thank You/Like Templates", accessible via the ACP under Templates & Style -> Templates).
 
-This plugin was originally created by <strong>-G33K-</strong> and modified for MyBB 1.8.x by <strong>ATofighi</strong> (the JavaScript part). It is currently maintained by <strong>Eldenroot</strong>, <strong>SvePu</strong>, <strong>Whiteneo</strong>, and <strong>Laird</strong>!
+## Upgrading
 
-Full credit goes to the original author, <strong>-G33K-</strong>. Without you, this plugin would not have been possible. :)
+### Upgrading to version 2.4.0 or above
 
-Contributing
-------------
+N.B. If you are upgrading **from** version 2.3.0 or earlier *and* MyAlerts is integrated *and* you don't want to lose any existing thanks/likes alerts, then see "Workaround to avoid loss of alerts" below.
+
+1. *Deactivate*.
+
+   Click the "Deactivate" button beside the Thank You/Like System plugin in the ACP "Plugins" module.
+
+2. *Download, extract, and copy files*.
+
+   Copy the new version's files, overwriting the old ones (per steps #1 and #2 of "Installing" above).
+
+3. *Reactivate*.
+
+   Activate the plugin again via the ACP. This will upgrade the plugin, retaining all data, including received and given thanks/likes, per-user counts of thanks/likes, overall thanks/likes statistics, the plugin's settings including per-usergroup settings, any changes made to the plugin's stylesheet, any changes made to the plugin's templates, and, if integrated with MyAlerts, all alerts of thanks/likes.
+
+4. *Update templates*.
+
+   If you had modified any of the plugin's templates, then, as when upgrading MyBB core, go to "Find Updated Templates" in the ACP to see whether you need to perform any updates.
+
+5. *Update the stylesheet*.
+
+   If you had modified the plugin's stylesheet (thankyoulike.css) for any themes, then you might need to apply any changes to this file that came with the new version of the plugin. You can check whether there are any changes in the new Master version of thankyoulike.css that need to be applied by clicking "View the Master theme's thankyoulike.css" under the plugin's entry in the ACP "Plugins" module and comparing it with your existing thankyoulike.css theme files (via the ACP under Templates & Style -> Themes).
+
+#### Workaround to avoid loss of alerts
+
+In version 2.3.0 and earlier, deactivating this plugin causes the thanks/likes MyAlerts alert type to be deleted from the database, thus orphaning any existing alerts of that type. When reactivating the plugin, including during an upgrade, the thanks/likes MyAlerts alert type is recreated with a different database ID, so the orphaned alerts remain invisible to your users.
+
+To work around this, assuming you have direct access to the database, simply take the following action:
+
+Prior to the first step of any upgrade procedure (deactivation/uninstallation), run this database query, taking note of the returned id (where 'mybb_' should, if necessary, be replaced with your table prefix):
+
+```sql
+SELECT id FROM mybb_alert_types WHERE code='tyl';
+```
+
+After (upgrading and) reactivating the plugin, run this database query, replacing "x" with the id returned by the previous query (and, again, replacing 'mybb_' if necessary):
+
+```sql
+UPDATE mybb_alert_types SET id=x WHERE code='tyl';
+```
+
+Then reload the 'mybbstuff_myalerts_alert_types' cache in the ACP under Tools & Maintenance -> Cache Manager.
+
+### Upgrading to version 2.3.0 or below
+
+#### When the updated version of the plugin does not contain new settings or changes to its templates or stylesheet
+
+N.B. If MyAlerts is integrated *and* you don't want to lose any existing thanks/likes alerts, then see "Workaround to avoid loss of alerts" above.
+
+1. *Deactivate*.
+
+   Click the "Deactivate" button beside the Thank You/Like System plugin in the ACP "Plugins" module.
+
+2. *Download, extract, and copy files*.
+
+   Copy the new version's files, overwriting the old ones (per steps #1 and #2 of "Installing" above).
+
+3. *Reactivate*.
+
+   Activate the plugin again via the ACP. All data except (unless you use the above workaround) for thanks/likes alerts will be retained, including received and given thanks/likes, per-user counts of thanks/likes, overall thanks/likes statistics, the plugin's settings including per-usergroup settings, any changes made to the plugin's stylesheet, and any changes made to the plugin's templates.
+
+#### When the updated version of the plugin **does** contain new settings or changes to its templates or stylesheet
+
+N.B. If MyAlerts is integrated *and* you don't want to lose any existing thanks/likes alerts, then see "Workaround to avoid loss of alerts" above.
+
+1. *Record changes*.
+
+   Make a note of your ACP settings for this plugin including per-usergroup settings (applicable when the plugin's "Usergroup-based thanks/likes limits" setting is enabled), any changes you have made to the plugin's stylesheet file ("thankyoulike.css", accessible via the ACP under Templates & Style -> Themes) and any changes you have made to the plugin's templates (under "Thank You/Like Templates", accessible via the ACP under Templates & Style -> Templates).
+
+2. *Uninstall*.
+
+   Click the "Uninstall" button beside the Thank You/Like System plugin in the ACP "Plugins" module and choose "NO" when asked whether to drop plugin data from the database.
+
+3. *Download, extract, and copy files*.
+
+   Copy the new version's files, overwriting the old ones (per steps #1 and #2 of "Installing" above).
+
+4. *Reinstall and reactivate*.
+
+   Install and activate the plugin again via the ACP.
+
+5. *Recreate changes*.
+
+   Re-enter your settings for the plugin including any per-usergroup settings and any changes you had made to the plugin's stylesheet and templates (this is why it is important to have made a note of them before uninstalling the plugin).
+
+## FAQ
+
+**How do I completely uninstall the Thank You/Like System plugin and remove all of its data from the database?**
+
+Click the "Uninstall" button beside the Thank You/Like System plugin in the "Plugins" module of the ACP and choose "YES" to drop all plugin data from database. This cannot be reverted. **All** data will be lost, including received and given thanks/likes, per-user counts of thanks/likes, overall thanks/likes statistics, plugin settings including per-usergroup settings, any changes made to the plugin's stylesheet and templates, and, if integrated with MyAlerts, all alerts of thanks/likes.
+
+**How do I change the icons of the buttons to add and remove thanks/likes?**
+
+Replace the files tyl_add.png and tyl_del.png in the images/thankyoulike directory.
+
+## Contributing
 
 Feel free to contribute, report a bug, or tell us your ideas!
 
-FAQ
----
+## Credits
 
-<strong>How do I completely uninstall the Thank You/Like System plugin and remove all of its data from the database?</strong>
+This plugin was originally created by **-G33K-** and modified for MyBB 1.8.x by **ATofighi** (the JavaScript part). It is currently maintained by **Eldenroot**, **SvePu**, **Whiteneo**, and **Laird**!
 
-Click the "Uninstall" button beside the Thank You/Like System plugin in the "Plugins" module of the ACP and choose "YES" to drop all plugin data from database. This cannot be reverted. <strong>All</strong> data will be lost, including received and given thanks/likes, per-user counts of thanks/likes, overall thanks/likes statistics, plugin settings including per-usergroup settings, and any changes made to the plugin's stylesheet and templates.
-
-<strong>How do I change the icons of the buttons to add and remove thanks/likes?</strong>
-
-Replace the files tyl_add.png and tyl_del.png in the images/thankyoulike directory.
+Full credit goes to the original author, **-G33K-**. Without you, this plugin would not have been possible. :)

--- a/inc/languages/english/admin/config_thankyoulike.lang.php
+++ b/inc/languages/english/admin/config_thankyoulike.lang.php
@@ -11,12 +11,13 @@ $l['tyl_info_desc_recount'] = "Recount thanks/likes";
 $l['tyl_info_desc_configsettings'] = "Configure Settings";
 $l['tyl_view_master_thankyoulike_css'] = "View the Master theme's thankyoulike.css";
 $l['tyl_use_this_css_for'] = "(use this after plugin upgrade to update this stylesheet in <a href=\"index.php?module=style-themes\">any themes</a> for which you have modified it).";
-$l['tyl_info_desc_alerts_error'] = "<b>The Thank You/Like System is uninstalled or deactivated</b>";
 $l['tyl_successful_upgrade_msg'] = "The {1} has been activated successfully and upgraded to version {2}.";
 $l['tyl_successful_upgrade_msg_for_info'] = "Successfully upgraded to version {1}.";
 $l['tyl_view_changelog'] = "View changelog.";
 $l['tyl_info_desc_alerts_integrate'] = "<b>Click <u>HERE</u> to integrate the Thank You/Like System with MyAlerts</b>";
-$l['tyl_info_desc_alerts_integrated'] = "<b>The Thank You/Like System and MyAlerts were integrated successfully!</b>";
+$l['tyl_info_desc_alerts_integrated'] = "<b>The Thank You/Like System is currently integrated with MyAlerts.</b>";
+$l['tyl_alerts_integration_success_msg'] = 'The Thank You/Like System was successfully integrated with MyAlerts!';
+$l['tyl_alerts_integration_failure_msg'] = 'Failed to integrate the Thank You/Like System with MyAlerts. Is MyAlerts version 2.0.0 or above installed and activated? If so, is it already integrated with the Thank You/Like System?';
 $l['tyl_info_desc_alerts_registeralerttype'] = "Register a new alert type into MyAlerts";
 
 $l['tyl_title'] = "Thank You/Like System";
@@ -134,7 +135,7 @@ $l['tyl_profile_box_post_allowvideocode_title'] = "Allow [video] Code";
 $l['tyl_profile_box_post_allowvideocode_desc'] = "Selecting \"Yes\" will enable the rendering of [video] MyCodes in profile page trophy posts.";
 
 $l['tyl_uninstall'] = 'Thank You/Like System - uninstallation';
-$l['tyl_uninstall_message'] = 'Do you wish to drop ALL plugin data from the database? (Selecting "No" will leave untouched thanks/likes given and received, per-user counts of thanks/likes, and overall thanks/likes statistics. It will not, however, prevent the removal of plugin settings (including any per-usergroup settings), nor will it prevent the removal of the plugin\'s CSS file, "thankyoulike.css" (including any changes you\'ve made to it), accessible via the ACP under Templates & Style -> <a href="index.php?module=style-themes">Themes</a>).';
+$l['tyl_uninstall_message'] = "Do you wish to drop ALL plugin data from the database? Selecting \"No\" will leave untouched:<ul><li>Entries for thanks/likes given and received.</li>\n<li>Per-user counts of thanks/likes.</li>\n<li>Overall thanks/likes statistics.</li>\n<li>The Thanks/Likes alert type and any of its alerts (only applies if MyAlerts integration is enabled).</li>\n</ul>\nSelecting \"No\" will <em>not</em>, however, prevent the removal of:<ul><li>Plugin settings (including any per-usergroup settings).</li>\n<li>The plugin's stylesheet, \"thankyoulike.css\" (including any changes you've made to it), accessible for each theme via the ACP's Templates & Style -> <a href=\"index.php?module=style-themes\">Themes</a> module.</li>\n<li>The plugin's templates (including any changes you've made to them), accessible  under \"Thank You/Like Templates\" for each template set via the ACP's Templates & Style -> <a href=\"index.php?module=style-templates\">Templates</a> module.</li>\n</ul>";
 
 $l['setting_thankyoulike_promotion_rcv'] = 'Thanks/likes received';
 $l['setting_thankyoulike_promotion_rcv_desc'] = 'Enter the number of received thanks/likes required. Thanks/Likes count must be selected as a required value for this to be included. Select the type of comparison for thanks/likes.';

--- a/thankyoulike.php
+++ b/thankyoulike.php
@@ -243,23 +243,8 @@ if($mybb->input['action'] == "add")
 	// Update user's last like add/del date
 	$db->update_query('users', array('tyl_lastadddeldate' => TIME_NOW), 'uid='.intval($mybb->user['uid']));
 
-	// Verify if myalerts exists and if compatible with 1.8.x then add alert type
-	include_once('inc/plugins/thankyoulike.php');
-	if(function_exists("myalerts_info")){
-		// Load myalerts info into an array
-		$my_alerts_info = myalerts_info();
-		// Set version info to a new var
-		$verify = $my_alerts_info['version'];
-		// If MyAlerts 2.0 or better then do this !!!
-		if($verify >= "2.0.0"){
-		global $cache;
-			// Load cache data and compare if version is the same or don't
-			$myalerts_plugins = $cache->read('mybbstuff_myalerts_alert_types');
-			if($myalerts_plugins['tyl']['code'] == 'tyl'){
-				tyl_recordAlertThankyou();
-			}
-		}
-	}
+	// If a compatible version of MyAlerts exists, then add an alert for this tyl.
+	tyl_recordAlertThankyou();
 
 	if($tlid)
 	{
@@ -349,8 +334,8 @@ if($mybb->input['action'] == "del")
 		{
 			// process delete
 			$db->delete_query($prefix."thankyoulike", "tlid='".$tyl_r['tlid']."'", "1");
-			// if alert of user was added and unread then review if delete thanks and delete alert too.
-			if((function_exists('myalerts_is_activated') && myalerts_is_activated()) && $mybb->user['uid']){
+			// If a compatible version of MyAlerts is active, then delete any unread alert for the deleted tyl.
+			if(tyl_have_myalerts() && $mybb->user['uid']){
 				$db->query("DELETE FROM ".TABLE_PREFIX."alerts WHERE from_user_id={$mybb->user['uid']} AND object_id='{$pid}' AND unread=1 LIMIT 1");
 			}
 			// Update user's last like add/del date


### PR DESCRIPTION
* Altered the plugin's logic so that now:
  1. The tyl alert type and any tyl alerts are now removed only when the plugin is uninstalled and the admin selects "Yes" to delete all data.
  2. When integrated with MyAlerts, the tyl alert type is disabled when the tyl plugin is deactivated, and (re)enabled when the tyl plugin is (re)activated.

* Abstracted MyAlerts-related code into reusable functions to avoid duplicated logic where possible.

* Updated README.md to document how to work around the old orphaning behaviour. Took the opportunity to at the same time rework the README to hopefully improve its readability.

* Made some miscellaneous changes to MyAlerts-related code to, for example, improve comments and fix indentation.