### PR TITLE
Fixes #195 - Trophy post content wordwrap

### DIFF
--- a/inc/plugins/thankyoulike.php
+++ b/inc/plugins/thankyoulike.php
@@ -614,7 +614,7 @@ function tyl_insert_templates()
 	<td class=\"trow2\"><strong>{\$lang->tyl_total_tyls_given}</strong></td>
 	<td class=\"trow2\">{\$memprofile['tyl_unumtyls']} ({\$tylpd_percent_total})<br /><span class=\"smalltext\">(<a href=\"tylsearch.php?action=usertylthreads&amp;uid={\$uid}\">{\$lang->tyl_find_threads}</a> &mdash; <a href=\"tylsearch.php?action=usertylposts&amp;uid={\$uid}\">{\$lang->tyl_find_posts}</a>)</span></td>
 </tr>",
-		'thankyoulike_member_profile_box'	=> "<table border=\"0\" cellspacing=\"{\$theme['borderwidth']}\" cellpadding=\"{\$theme['tablespace']}\" width=\"100%\" class=\"tborder\">
+		'thankyoulike_member_profile_box'	=> "<table border=\"0\" cellspacing=\"{\$theme['borderwidth']}\" cellpadding=\"{\$theme['tablespace']}\" width=\"100%\" class=\"tborder tfixed\">
 <tr>
 <td colspan=\"2\" class=\"thead\"><strong>{\$lang->tyl_profile_box_thead}</strong></td>
 </tr>


### PR DESCRIPTION
This simple css will fix the mentioned issue.

![image](https://user-images.githubusercontent.com/778890/43084898-e000ae2c-8e99-11e8-994d-b744c05b5aa0.png)
